### PR TITLE
Add FAR/NEAR configs for the rocket fins

### DIFF
--- a/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Wing01.cfg
+++ b/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Wing01.cfg
@@ -46,3 +46,21 @@ deflectionLiftCoeff = 0.3
 
 
 }
+
+@PART[SR_Wing01]:NEEDS[FerramAerospaceResearch|NEAR]
+{
+    @module = Part
+    @maximum_drag = 0
+    @minimum_drag = 0
+    @angularDrag = 0
+    !dragCoeff = DELETE
+    !deflectionLiftCoeff = DELETE
+    MODULE
+    {
+        name = FARWingAerodynamicModel
+        MAC = 0.9746
+        MidChordSweep = 0
+        b_2 = 0.9749
+        TaperRatio = 0.9492
+    }
+}

--- a/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Wing02.cfg
+++ b/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Wing02.cfg
@@ -46,3 +46,21 @@ deflectionLiftCoeff = 0.2
 
 
 }
+
+@PART[SR_Wing02]:NEEDS[FerramAerospaceResearch|NEAR]
+{
+    @module = Part
+    @maximum_drag = 0
+    @minimum_drag = 0
+    @angularDrag = 0
+    !dragCoeff = DELETE
+    !deflectionLiftCoeff = DELETE
+    MODULE
+    {
+        name = FARWingAerodynamicModel
+        MAC = 0.625
+        MidChordSweep = 23.12
+        b_2 = 0.5
+        TaperRatio = 0.6667
+    }
+}

--- a/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Wing03.cfg
+++ b/GameData/UmbraSpaceIndustries/SoundingRockets/Parts/SR_Wing03.cfg
@@ -46,3 +46,21 @@ deflectionLiftCoeff = 0.1
 
 
 }
+
+@PART[SR_Wing03]:NEEDS[FerramAerospaceResearch|NEAR]
+{
+    @module = Part
+    @maximum_drag = 0
+    @minimum_drag = 0
+    @angularDrag = 0
+    !dragCoeff = DELETE
+    !deflectionLiftCoeff = DELETE
+    MODULE
+    {
+        name = FARWingAerodynamicModel
+        MAC = 0.625
+        MidChordSweep = 4.07
+        b_2 = 0.3
+        TaperRatio = 0.6667
+    }
+}


### PR DESCRIPTION
Adds ModuleManager configs that will replace the stock wing module with
FAR wing modules if FAR or NEAR are present.
