### PR TITLE
Update version file URL to current repo owner

### DIFF
--- a/FOR_RELEASE/GameData/UmbraSpaceIndustries/SoundingRockets/SoundingRockets.version
+++ b/FOR_RELEASE/GameData/UmbraSpaceIndustries/SoundingRockets/SoundingRockets.version
@@ -1,9 +1,9 @@
 {
      "NAME":"Sounding Rockets",
-     "URL":"https://raw.githubusercontent.com/BobPalmer/SoundingRockets/master/FOR_RELEASE/GameData/UmbraSpaceIndustries/SoundingRockets/SoundingRockets.version",
-     "DOWNLOAD":"https://github.com/BobPalmer/SoundingRockets/releases",
+     "URL":"https://raw.githubusercontent.com/UmbraSpaceIndustries/SoundingRockets/master/FOR_RELEASE/GameData/UmbraSpaceIndustries/SoundingRockets/SoundingRockets.version",
+     "DOWNLOAD":"https://github.com/UmbraSpaceIndustries/SoundingRockets/releases",
      "GITHUB":{
-         "USERNAME":"BobPalmer",
+         "USERNAME":"UmbraSpaceIndustries",
          "REPOSITORY":"SoundingRockets",
          "ALLOW_PRE_RELEASE":false
      },


### PR DESCRIPTION
Hi @BobPalmer,

The URLs in this mod's version file are slightly out of date, they still have the previous repo owner. GitHub helpfully silently redirects them, so they still work, but this can sometimes trrigger GitHub's server-side rate limiting behavior.

Now they're updated to the latest correct values.